### PR TITLE
Centralise configurations from hard-coded code snippets

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+"""
+Minimal runtime configuration for CoMaPOI.
+各位复现时请注意, 以下配置项可根据实际环境进行调整:
+"""
+
+from pathlib import Path
+
+# Project-relative roots
+DATASET_ROOT = Path("dataset_all")
+LEGACY_DATASET_ROOT = Path("dataset")
+FINETUNE_DATA_ROOT = Path("finetune") / "data"
+FINETUNE_RESULTS_ROOT = Path("finetune") / "results"
+
+# API defaults
+DEFAULT_VLLM_HOST = "localhost"
+DEFAULT_PORT_INVERSE = 7863
+
+# Dataset defaults
+DATASET_MAX_ITEM = {"nyc": 5091, "tky": 7851, "ca": 13630}
+DATASET_TRAIN_SAMPLES = {"nyc": 3870, "tky": 11850, "ca": 6616}
+
+
+def vllm_base_url(host: str, port: int) -> str:
+    return f"http://{host}:{port}/v1"

--- a/finetune_sft_new.py
+++ b/finetune_sft_new.py
@@ -23,6 +23,7 @@ import json
 import re
 import time
 import random
+from pathlib import Path
 from typing import Dict, List, Tuple, Optional, Any, Union
 
 import torch
@@ -50,6 +51,7 @@ from peft import get_peft_model, LoraConfig
 from datasets import load_dataset
 
 from utils import convert_content_to_string
+from config import DATASET_MAX_ITEM, FINETUNE_DATA_ROOT, FINETUNE_RESULTS_ROOT
 
 
 # Helper functions for data processing
@@ -644,6 +646,18 @@ def get_args():
     parser.add_argument("--type", default='merged', type=str, help="Training type (merged, agent1, agent2, agent3)")
     parser.add_argument("--unsloth", action="store_true", help="Use Unsloth acceleration (single GPU only, not compatible with phi3.5)")
     parser.add_argument('--op_str', type=str, default='4-14', help='Operation string for output directory naming')
+    parser.add_argument(
+        "--finetune_data_root",
+        type=str,
+        default=str(FINETUNE_DATA_ROOT),
+        help="Root path for fine-tune data",
+    )
+    parser.add_argument(
+        "--finetune_results_root",
+        type=str,
+        default=str(FINETUNE_RESULTS_ROOT),
+        help="Root path for fine-tune outputs",
+    )
 
     return parser.parse_args()
 
@@ -657,38 +671,41 @@ def main():
 
     # Parse arguments
     args = get_args()
+    data_root = Path(args.finetune_data_root)
+    results_root = Path(args.finetune_results_root)
+    dataset_root = data_root / args.dataset
 
     # Set up file paths for different agent types
-    agent1_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent1_train_samples.jsonl'
-    agent2_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent2_train_samples.jsonl'
-    agent3_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent3_train_samples.jsonl'
+    agent1_path = str(dataset_root / "agent1_train_samples.jsonl")
+    agent2_path = str(dataset_root / "agent2_train_samples.jsonl")
+    agent3_path = str(dataset_root / "agent3_train_samples.jsonl")
 
     # Process data based on agent type
     if args.type == 'agent1':
-        cleaned_train_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent1_train_samples_all.jsonl'
-        cleaned_test_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent1_train_samples_100.jsonl'
+        cleaned_train_file_path = str(dataset_root / "agent1_train_samples_all.jsonl")
+        cleaned_test_file_path = str(dataset_root / "agent1_train_samples_100.jsonl")
         DataProcessor.check_and_process_files(agent1_path, cleaned_train_file_path, cleaned_test_file_path, test_size=100)
         args.data_path = cleaned_train_file_path
 
     elif args.type == 'agent2':
-        cleaned_train_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent2_train_samples_all.jsonl'
-        cleaned_test_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent2_train_samples_100.jsonl'
+        cleaned_train_file_path = str(dataset_root / "agent2_train_samples_all.jsonl")
+        cleaned_test_file_path = str(dataset_root / "agent2_train_samples_100.jsonl")
         DataProcessor.check_and_process_files(agent2_path, cleaned_train_file_path, cleaned_test_file_path, test_size=100)
         args.data_path = cleaned_train_file_path
 
     elif args.type == 'agent3':
-        cleaned_train_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent3_train_samples_all.jsonl'
-        cleaned_test_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/agent3_train_samples_100.jsonl'
+        cleaned_train_file_path = str(dataset_root / "agent3_train_samples_all.jsonl")
+        cleaned_test_file_path = str(dataset_root / "agent3_train_samples_100.jsonl")
         DataProcessor.check_and_process_files(agent3_path, cleaned_train_file_path, cleaned_test_file_path, test_size=100)
         args.data_path = cleaned_train_file_path
 
     elif args.type == 'merged':
-        merged_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/total_agent_train_samples.jsonl'
+        merged_file_path = str(dataset_root / "total_agent_train_samples.jsonl")
         # Merge long-term profiles (from agent1), short-term profiles (from agent2), and agent3's reverse inference fine-tuning data
         DataProcessor.merge_agent_files(agent1_path, agent2_path, agent3_path, merged_file_path)
 
-        cleaned_train_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/cleaned_total_agent_train_samples_all.jsonl'
-        cleaned_test_file_path = f'/home/ZhongLin/SMAC/finetune/data/{args.dataset}/cleaned_total_agent_train_samples_100.jsonl'
+        cleaned_train_file_path = str(dataset_root / "cleaned_total_agent_train_samples_all.jsonl")
+        cleaned_test_file_path = str(dataset_root / "cleaned_total_agent_train_samples_100.jsonl")
         DataProcessor.check_and_process_files(merged_file_path, cleaned_train_file_path, cleaned_test_file_path, test_size=100)
         args.data_path = cleaned_train_file_path
 
@@ -696,13 +713,13 @@ def main():
         args.data_path = f"dataset_all/{args.dataset}/train/{args.dataset}_train.jsonl"
 
     # Set dataset-specific parameters
-    args.max_item = {"nyc": 5091, "tky": 7851, "ca": 13630}.get(args.dataset, 5091)
+    args.max_item = DATASET_MAX_ITEM.get(args.dataset, 5091)
 
     # Set up model path and output directories
-    args.model_path = args.model_path + args.model
+    args.model_path = os.path.join(args.model_path, args.model)
     args.run_name = f'bs{args.batch_size}-gas{args.gradient_accumulation_steps}-ms{args.max_steps}-{args.type}-lr{args.learning_rate}'
     args.save_name = f'bs{args.batch_size}-gas{args.gradient_accumulation_steps}-ms{args.max_steps}-{args.type}-lr{args.learning_rate}'
-    args.output_dir = f"/home/ZhongLin/SMAC/finetune/results/{args.op_str}/sft-{args.dataset}/{args.save_name}"
+    args.output_dir = str(results_root / args.op_str / f"sft-{args.dataset}" / args.save_name)
 
     # Print arguments
     print("Parameter list:")

--- a/inference_inverse_new.py
+++ b/inference_inverse_new.py
@@ -22,6 +22,13 @@ from prompt_provider import PromptProvider
 from ft_data import *
 from agentscope.message import Msg
 from agentscope.service import ServiceToolkit
+from config import (
+    DEFAULT_PORT_INVERSE,
+    DEFAULT_VLLM_HOST,
+    DATASET_MAX_ITEM,
+    DATASET_TRAIN_SAMPLES,
+    vllm_base_url,
+)
 
 
 # Helper functions for multiprocessing
@@ -42,7 +49,7 @@ def init_agents(args):
             "model_name": f"{args.api_type}",
             "api_key": "EMPTY",
             "client_args": {
-                "base_url": "http://localhost:7863/v1"
+                "base_url": vllm_base_url(args.host, args.port)
             },
             "generate_args": {
                 "temperature": 0.5,
@@ -57,7 +64,7 @@ def init_agents(args):
             "model_name": f"{args.api_type}",
             "api_key": "EMPTY",
             "client_args": {
-                "base_url": "http://localhost:7863/v1"
+                "base_url": vllm_base_url(args.host, args.port)
             },
             "generate_args": {
                 "temperature": 0.2,
@@ -386,8 +393,21 @@ def single_predict_worker(params):
     """
     try:
         selected_sample, args, user_to_candidate_map = params
-        user_id, subtrajectory_id, label, current_trajectory = parse_user_and_trajectory_train(
-            selected_sample.get('messages', []))  # Parse user ID and current trajectory from messages
+        # Author guidance: parse_user_and_trajectory is sufficient.
+        user_id, label, current_trajectory = parse_user_and_trajectory(
+            selected_sample.get('messages', [])
+        )
+        if user_id is None or label is None or current_trajectory is None:
+            raise ValueError("Failed to parse user_id/label/current_trajectory from sample.")
+        if isinstance(label, list):
+            if not label:
+                raise ValueError("Parsed label list is empty.")
+            label = label[0]
+        subtrajectory_id = "0"
+        if current_trajectory:
+            sub_match = re.search(r'"subtrajectory_id":\s*"?(\d+)"?', current_trajectory)
+            if sub_match:
+                subtrajectory_id = sub_match.group(1)
 
         # Initialize agents in this process
         generator, generator_value = init_agents(args)
@@ -406,7 +426,12 @@ def single_predict_worker(params):
         next_poi_info = [label_id, category, lat, lon]
         inverse_prompter = Inverse_prompter(args, user_id, subtrajectory_id, current_trajectory, next_poi_info)
         forward_prompter = Forwar_prompter(args, user_id, subtrajectory_id, current_trajectory, next_poi_info)
-        rag_candidates = user_to_candidate_map[user_id]
+        rag_candidates = user_to_candidate_map.get(user_id, [])
+        if not rag_candidates:
+            try:
+                rag_candidates = user_to_candidate_map.get(int(user_id), [])
+            except (TypeError, ValueError):
+                pass
         rag_candidates = [int(candidate) for candidate in rag_candidates[:100]]
 
         # Generate historical distribution
@@ -639,7 +664,7 @@ class InverseInferenceProcessor:
                 "messages": [
                     {"role": "system", "content": "You are a helpful assistant."},
                     {"role": "user", "content": str(user_content3)},
-                    {"role": "assistant", "content": str(assistant_content)}
+                    {"role": "assistant", "content": str(assistant_content3)}
                 ]
             }
             entries3.append(entry_dict3)
@@ -829,14 +854,16 @@ def main():
     parser.add_argument('--batch_size', type=int, default=32, help='Number of concurrent processes')
     parser.add_argument('--mode', type=str, default='train', help='Mode (train/test)')
     parser.add_argument('--save_id', type=str, default='N1', help='Save ID (N1-N...; T1-T...; C1-C...)')
+    parser.add_argument('--host', type=str, default=DEFAULT_VLLM_HOST, help='Host for API server')
+    parser.add_argument('--port', type=int, default=DEFAULT_PORT_INVERSE, help='Port for API server')
 
     args = parser.parse_args()
     dataset = args.dataset
 
     # Set dataset-specific parameters
-    args.max_item = {"nyc": 5091, "tky": 7851, "ca": 13630}.get(dataset, 5091)
+    args.max_item = DATASET_MAX_ITEM.get(dataset, 5091)
     if args.num_samples == 0:
-        args.num_samples = {"nyc": 3870, "tky": 11850, "ca": 6616}.get(dataset, 3870)  # train 3870, 11850, 6616
+        args.num_samples = DATASET_TRAIN_SAMPLES.get(dataset, 3870)
 
     print("Starting inverse inference with arguments:", args)
 


### PR DESCRIPTION
## Summary

Many thanks for sharing CoMaPOI with the community and enabling reproducible follow-up research. This PR improves configuration portability with minimal intrusion:

- Add a small `config.py` for centralized runtime defaults (paths/ports/dataset constants).
- Replace machine-specific hardcoded paths with project-relative/configurable paths.
- Improve `poi_info.csv` lookup and provide clearer error messages when missing.

## Why

This makes the codebase easier to run across different environments (local, server, different OS) and simplifies reproduction setup.

## Scope

- Configuration/engineering improvement only.
- No intended model or method change.
